### PR TITLE
Inject adapter from binding in service provider

### DIFF
--- a/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
+++ b/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
@@ -64,7 +64,7 @@ class LaravelGettextServiceProvider extends ServiceProvider
                 // symfony translator implementation
                 $translator = new Translators\Symfony(
                     $configuration->get(),
-                    new Adapters\LaravelAdapter,
+                    $this->app->make('Adapters/AdapterInterface'),
                     $fileSystem,
                     $storage
                 );
@@ -72,7 +72,7 @@ class LaravelGettextServiceProvider extends ServiceProvider
                 // GNU/Gettext php extension
                 $translator = new Translators\Gettext(
                     $configuration->get(),
-                    new Adapters\LaravelAdapter,
+                    $this->app->make('Adapters/AdapterInterface'),
                     $fileSystem,
                     $storage
                 );


### PR DESCRIPTION
Currently, setting the Adapter in config is not useful unless the binding is injected into Translator, any custom class passed into config is not currently being used.

On line 49 the binding is made to the Application but will only be used when Application needs to resolve dependancy, but since the Translator is receiving the Adapter explicitly the Application does not attempt to resolve it currently - that's not a problem but we just need to make sure what we are passing explicitly is the same as what the Application would resolve, this change fixes that issue.