### PR TITLE
Make Laravel 5.7 Compatible official

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     },
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6"
+        "laravel/framework": "^5.7"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~7.0",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^5.6",
+        "laravel/laravel": "^5.7",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 5.7 came out 2  days ago and I just tested and it works fine. Maybe update the documentation accordingly? 