### PR TITLE
Adding support for subdirectories

### DIFF
--- a/src/Xinax/LaravelGettext/FileSystem.php
+++ b/src/Xinax/LaravelGettext/FileSystem.php
@@ -78,7 +78,7 @@ class FileSystem {
             $path = $this->basePath . DIRECTORY_SEPARATOR . $path;
 
             $fs = new \Illuminate\Filesystem\Filesystem($path);
-            $glob = $fs->glob(realpath($path) . '/{,**/}*.php', GLOB_BRACE);
+            $glob = $fs->allFiles(realpath($path));
             $compiler = new \Illuminate\View\Compilers\BladeCompiler($fs, $domainDir);
 
             foreach ($glob as $file) {


### PR DESCRIPTION
Adding support in v1.x for subdirectories deeper then 2 levels.
Just the same as in LaravelGettext v2.x. Need to be compatible to Laravel 4.2 atm :(.